### PR TITLE
Polish customer orders view

### DIFF
--- a/admin/TODO.md
+++ b/admin/TODO.md
@@ -26,11 +26,11 @@ Legend
 - [ ] Confirm modal + error banner components reused across delete/demote/approve actions, consuming backend error shape `{ error: { ... } }`.
   - Note: Error banner component shipped and integrated in dashboard, products list, product form, and returns list; continue rollout across remaining screens.
 - [ ] Loading states for primary tables/forms to avoid blank flashes while waiting for API responses.
-  - Note: Implemented on dashboard, products list, product form, and returns list; consider extracting a shared loading wrapper.
+  - Note: Implemented on dashboard, products list, product form, customer orders list, and returns list; consider extracting a shared loading wrapper.
 - [ ] Material design polish: base layouts/screens on Angular Material components with responsive grids, typography, and stateful cards (no barebones UI).
-  - Started: Admin Orders list migrated to Material table + paginator.
+  - Continued: Customer orders list rebuilt with Material table, paginator, and responsive create-order form.
 - [ ] Localization coverage: route every label, helper, toast, and error through i18n translation files; keep copy out of components.
-  - Note: Added returns translations and fixed categories parent "none" label; continue replacing remaining inline strings.
+  - Note: Added returns translations and fixed categories parent "none" label; orders list now fully localized; continue replacing remaining inline strings.
 
 ## P1 - Next Wave
 - [ ] Auth preferences UI (`GET/PATCH /api/auth/preferences`): locale dropdown + notification toggles.
@@ -89,6 +89,7 @@ Legend
 
 ### Orders & Returns
 - [x] Customer orders list/detail (`GET /api/orders*`).
+  - Polished: Customer-facing list now uses Material table + paginator with responsive layout and i18n copy.
 - [ ] Invoice download + timeline view (`GET /api/orders/{id}/invoice|timeline`).
 - [ ] Return request form (`POST /api/orders/{id}/returns`).
 - [x] Admin orders list/detail/update (`/api/admin/orders*`).

--- a/admin/angular.json
+++ b/admin/angular.json
@@ -75,5 +75,8 @@
                                                                }
                                                  }
                                }
-                 }
+                },
+                "cli": {
+                  "analytics": false
+                }
 }

--- a/admin/src/app/pages/orders/orders-list.component.html
+++ b/admin/src/app/pages/orders/orders-list.component.html
@@ -1,35 +1,147 @@
-<div class="panel">
-  <h2>My Orders</h2>
-  <div class="row" style="align-items:flex-end;">
-    <div><label class="muted">Page</label><input [(ngModel)]="page" type="number" min="1"></div>
-    <div><label class="muted">Limit</label><input [(ngModel)]="limit" type="number" min="1"></div>
-    <div><button (click)="load()">Apply</button></div>
-    <div class="spacer"></div>
-    <div>
-      <label class="muted">Shipping</label>
-      <input [(ngModel)]="shipping" type="number" min="0" step="0.01">
+<div class="orders-shell">
+  <section class="orders-header panel">
+    <div class="orders-header-text">
+      <h1>{{ 'orders.list.title' | translate }}</h1>
+      <p class="muted">{{ 'orders.list.subtitle' | translate }}</p>
     </div>
-    <div>
-      <label class="muted">Tax rate</label>
-      <input [(ngModel)]="taxRate" type="number" min="0" max="1" step="0.01">
-    </div>
-    <div>
-      <button (click)="createOrder()">Create Order from Cart</button>
-    </div>
-  </div>
-  <p *ngIf="loading" class="muted">Loading…</p>
-  <p *ngIf="error" class="muted">{{ error }}</p>
-  <table *ngIf="data">
-    <thead><tr><th>ID</th><th>Total</th><th>Status</th><th>Placed</th><th></th></tr></thead>
-    <tbody>
-      <tr *ngFor="let o of data.items">
-        <td>{{ o._id }}</td>
-        <td>{{ o.total | number:'1.2-2' }} {{ o.currency }}</td>
-        <td>{{ o.status }} / {{ o.paymentStatus }}</td>
-        <td>{{ o['createdAt'] | date:'short' }}</td>
-        <td><a [routerLink]="['/orders', o._id]"><button>View</button></a></td>
-      </tr>
-    </tbody>
-  </table>
-</div>
+    <button mat-stroked-button color="primary" type="button" (click)="load()" [disabled]="loading">
+      <mat-icon>refresh</mat-icon>
+      {{ 'orders.list.actions.refresh' | translate }}
+    </button>
+  </section>
 
+  <section class="orders-create panel">
+    <header class="section-heading">
+      <h2>{{ 'orders.list.create.title' | translate }}</h2>
+      <p class="muted">{{ 'orders.list.create.subtitle' | translate }}</p>
+    </header>
+
+    <form [formGroup]="createForm" (ngSubmit)="createOrder()" class="create-form" novalidate>
+      <div class="form-grid">
+        <mat-form-field appearance="fill">
+          <mat-label>{{ 'orders.list.create.fields.shipping' | translate }}</mat-label>
+          <input matInput type="number" min="0" step="0.01" formControlName="shipping" />
+          <mat-hint>{{ 'orders.list.create.fields.shippingHint' | translate }}</mat-hint>
+          <mat-error *ngIf="createForm.controls.shipping.hasError('min')">
+            {{ 'orders.list.create.errors.shippingMin' | translate }}
+          </mat-error>
+        </mat-form-field>
+
+        <mat-form-field appearance="fill">
+          <mat-label>{{ 'orders.list.create.fields.taxRate' | translate }}</mat-label>
+          <input matInput type="number" min="0" max="1" step="0.01" formControlName="taxRate" />
+          <mat-hint>{{ 'orders.list.create.fields.taxRateHint' | translate }}</mat-hint>
+          <mat-error *ngIf="createForm.controls.taxRate.hasError('min') || createForm.controls.taxRate.hasError('max')">
+            {{ 'orders.list.create.errors.taxRateRange' | translate }}
+          </mat-error>
+        </mat-form-field>
+      </div>
+
+      <div class="actions">
+        <button
+          mat-stroked-button
+          color="accent"
+          type="submit"
+          [disabled]="createForm.invalid || creating"
+        >
+          <ng-container *ngIf="!creating; else creatingSpinner">
+            <mat-icon>shopping_cart_checkout</mat-icon>
+          </ng-container>
+          <ng-template #creatingSpinner>
+            <mat-progress-spinner diameter="18" mode="indeterminate"></mat-progress-spinner>
+          </ng-template>
+          <span>{{ 'orders.list.create.submit' | translate }}</span>
+        </button>
+      </div>
+    </form>
+  </section>
+
+  <section class="orders-table panel">
+    <header class="section-heading">
+      <h2>{{ 'orders.list.table.title' | translate }}</h2>
+      <p class="muted" *ngIf="total > 0">{{ 'orders.list.table.count' | translate:{ count: total } }}</p>
+    </header>
+
+    <div class="table-container">
+      <app-loading [show]="loading" labelKey="common.loading"></app-loading>
+
+      <table mat-table [dataSource]="dataSource" *ngIf="dataSource.length; else emptyState">
+        <ng-container matColumnDef="id">
+          <th mat-header-cell *matHeaderCellDef>{{ 'orders.list.table.id' | translate }}</th>
+          <td mat-cell *matCellDef="let order">
+            <span class="order-id" [matTooltip]="order._id">{{ order._id }}</span>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="total">
+          <th mat-header-cell *matHeaderCellDef>{{ 'orders.list.table.total' | translate }}</th>
+          <td mat-cell *matCellDef="let order">
+            {{ order.total | currency:(order.currency || 'USD'):'symbol':'1.2-2' }}
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="status">
+          <th mat-header-cell *matHeaderCellDef>{{ 'orders.list.table.status' | translate }}</th>
+          <td mat-cell *matCellDef="let order">
+            <div class="status-group">
+              <span
+                class="status-chip"
+                [ngClass]="statusChipClass(order.status)"
+                [translate]="statusKey(order.status, 'status')"
+                [translateParams]="{ defaultValue: order.status || '' }"
+              ></span>
+              <span
+                class="status-chip outline"
+                [ngClass]="statusChipClass(order.paymentStatus)"
+                [translate]="statusKey(order.paymentStatus, 'paymentStatus')"
+                [translateParams]="{ defaultValue: order.paymentStatus || '' }"
+              ></span>
+            </div>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="placed">
+          <th mat-header-cell *matHeaderCellDef>{{ 'orders.list.table.placed' | translate }}</th>
+          <td mat-cell *matCellDef="let order">
+            {{ order.createdAt | date:'medium' }}
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef>{{ 'orders.list.table.actions' | translate }}</th>
+          <td mat-cell *matCellDef="let order">
+            <button
+              mat-icon-button
+              color="primary"
+              [routerLink]="['/orders', order._id]"
+              [attr.aria-label]="'orders.list.table.view' | translate"
+            >
+              <mat-icon>open_in_new</mat-icon>
+            </button>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let order; columns: displayedColumns; trackBy: trackById"></tr>
+      </table>
+
+      <ng-template #emptyState>
+        <div class="empty-state">
+          <mat-icon>inventory_2</mat-icon>
+          <p>{{ 'orders.list.empty' | translate }}</p>
+        </div>
+      </ng-template>
+    </div>
+
+    <mat-paginator
+      [length]="total"
+      [pageIndex]="pageIndex"
+      [pageSize]="pageSize"
+      [pageSizeOptions]="pageSizeOptions"
+      showFirstLastButtons
+      (page)="onPageChange($event)"
+    ></mat-paginator>
+  </section>
+
+  <app-error-banner [key]="errorKey" [error]="lastError"></app-error-banner>
+</div>

--- a/admin/src/app/pages/orders/orders-list.component.scss
+++ b/admin/src/app/pages/orders/orders-list.component.scss
@@ -1,0 +1,160 @@
+.orders-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.orders-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.orders-header-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.orders-header-text h1 {
+  margin: 0;
+}
+
+.section-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 16px;
+}
+
+.section-heading h2 {
+  margin: 0;
+}
+
+.muted {
+  margin: 0;
+  color: var(--app-text-muted);
+}
+
+.create-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.actions button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.actions mat-progress-spinner {
+  width: 18px;
+  height: 18px;
+}
+
+.table-container {
+  position: relative;
+  overflow-x: auto;
+}
+
+.table-container table {
+  width: 100%;
+}
+
+.order-id {
+  font-family: 'Fira Code', 'Roboto Mono', monospace;
+  font-size: 13px;
+}
+
+.status-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  background: rgba(15, 23, 42, 0.06);
+  color: var(--app-text);
+  text-transform: capitalize;
+}
+
+.status-chip.success {
+  background: rgba(34, 197, 94, 0.15);
+  color: var(--app-success);
+}
+
+.status-chip.warning {
+  background: rgba(217, 119, 6, 0.15);
+  color: var(--app-warning);
+}
+
+.status-chip.danger {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--app-danger);
+}
+
+.status-chip.neutral {
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--app-text-muted);
+}
+
+.status-chip.outline {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: transparent;
+  color: var(--app-text-muted);
+}
+
+.empty-state {
+  padding: 48px 0;
+  display: grid;
+  gap: 8px;
+  justify-items: center;
+  color: var(--app-text-muted);
+}
+
+.empty-state mat-icon {
+  font-size: 40px;
+  width: 40px;
+  height: 40px;
+}
+
+.mat-mdc-paginator {
+  border-top: 1px solid var(--app-border);
+  margin-top: 16px;
+}
+
+@media (max-width: 767px) {
+  .orders-header {
+    align-items: flex-start;
+  }
+
+  .actions {
+    justify-content: stretch;
+  }
+
+  .actions button {
+    width: 100%;
+  }
+}

--- a/admin/src/app/pages/orders/orders-list.component.ts
+++ b/admin/src/app/pages/orders/orders-list.component.ts
@@ -1,33 +1,139 @@
-import { Component, OnInit } from '@angular/core';
-import { OrdersService, Order, Paginated } from '../../services/orders.service';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { FormBuilder, Validators } from '@angular/forms';
+import { PageEvent } from '@angular/material/paginator';
+import { TranslateService } from '@ngx-translate/core';
 
-@Component({ selector: 'app-orders-list', templateUrl: './orders-list.component.html' })
+import { OrdersService, Order } from '../../services/orders.service';
+import { ToastService } from '../../core/toast.service';
+
+@Component({
+  selector: 'app-orders-list',
+  templateUrl: './orders-list.component.html',
+  styleUrls: ['./orders-list.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
 export class OrdersListComponent implements OnInit {
-  page = 1;
-  limit = 10;
+  readonly createForm = this.fb.group({
+    shipping: [0, [Validators.min(0)]],
+    taxRate: [0, [Validators.min(0), Validators.max(1)]]
+  });
+
+  displayedColumns: string[] = ['id', 'total', 'status', 'placed', 'actions'];
+  dataSource: Order[] = [];
+  total = 0;
+  pageIndex = 0;
+  pageSize = 10;
+  readonly pageSizeOptions = [5, 10, 25, 50];
+
   loading = false;
-  error = '';
-  data: Paginated<Order> | null = null;
-  shipping = 0;
-  taxRate = 0;
+  creating = false;
+  errorKey: string | null = null;
+  lastError: any = null;
 
-  constructor(private orders: OrdersService) {}
+  private readonly statusTone: Record<string, 'success' | 'warning' | 'danger' | 'neutral'> = {
+    pending: 'warning',
+    processing: 'warning',
+    confirmed: 'warning',
+    paid: 'success',
+    fulfilled: 'success',
+    completed: 'success',
+    shipped: 'success',
+    delivered: 'success',
+    refunded: 'danger',
+    cancelled: 'danger',
+    failed: 'danger',
+    unpaid: 'warning'
+  };
 
-  ngOnInit() { this.load(); }
+  constructor(
+    private readonly orders: OrdersService,
+    private readonly fb: FormBuilder,
+    private readonly toast: ToastService,
+    private readonly translate: TranslateService,
+    private readonly cdr: ChangeDetectorRef
+  ) {}
 
-  load() {
-    this.loading = true; this.error = '';
-    this.orders.list({ page: this.page, limit: this.limit }).subscribe({
-      next: (res) => { this.data = res; this.loading = false; },
-      error: (err) => { this.loading = false; this.error = err?.error?.error?.message || 'Failed'; }
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.loading = true;
+    this.errorKey = null;
+    this.lastError = null;
+    this.cdr.markForCheck();
+
+    this.orders.list({ page: this.pageIndex + 1, limit: this.pageSize }).subscribe({
+      next: (res) => {
+        this.dataSource = res.items;
+        this.total = res.total;
+        this.pageIndex = Math.max(res.page - 1, 0);
+        this.loading = false;
+        this.cdr.markForCheck();
+      },
+      error: (err) => {
+        this.lastError = err;
+        const code = err?.error?.error?.code;
+        this.errorKey = code ? `errors.backend.${code}` : 'orders.list.errors.loadFailed';
+        this.loading = false;
+        this.cdr.markForCheck();
+      }
     });
   }
 
-  createOrder() {
-    this.orders.create({ shipping: this.shipping, taxRate: this.taxRate }).subscribe({
-      next: () => this.load(),
-      error: (err) => { this.error = err?.error?.error?.message || 'Create failed'; }
+  onPageChange(event: PageEvent): void {
+    if (this.pageSize !== event.pageSize) {
+      this.pageSize = event.pageSize;
+    }
+    this.pageIndex = event.pageIndex;
+    this.load();
+  }
+
+  createOrder(): void {
+    if (this.creating || this.createForm.invalid) {
+      this.createForm.markAllAsTouched();
+      return;
+    }
+
+    const shipping = Number(this.createForm.value.shipping ?? 0) || 0;
+    const taxRate = Number(this.createForm.value.taxRate ?? 0) || 0;
+
+    this.creating = true;
+    this.cdr.markForCheck();
+
+    this.orders.create({ shipping, taxRate }).subscribe({
+      next: () => {
+        this.toast.success(this.translate.instant('orders.list.toasts.created'));
+        this.creating = false;
+        this.load();
+        this.cdr.markForCheck();
+      },
+      error: (err) => {
+        this.lastError = err;
+        const code = err?.error?.error?.code;
+        this.errorKey = code ? `errors.backend.${code}` : 'orders.list.errors.createFailed';
+        this.creating = false;
+        this.toast.error(this.translate.instant('orders.list.errors.createFailed'));
+        this.cdr.markForCheck();
+      }
     });
+  }
+
+  statusChipClass(value: string | undefined | null): string {
+    if (!value) {
+      return 'neutral';
+    }
+    const tone = this.statusTone[value.toLowerCase()] ?? 'neutral';
+    return tone;
+  }
+
+  statusKey(value: string | undefined | null, scope: 'status' | 'paymentStatus'): string {
+    const normalized = value?.toLowerCase() || 'unknown';
+    return `orders.list.${scope}.${normalized}`;
+  }
+
+  trackById(_: number, order: Order): string {
+    return order._id;
   }
 }
 

--- a/admin/src/assets/i18n/en.json
+++ b/admin/src/assets/i18n/en.json
@@ -1,4 +1,7 @@
 ﻿{
+    "common": {
+        "loading": "Loading…"
+    },
     "denied":  {
                    "title":  "Access denied",
                    "message":  "You do not have permission to view this page or perform this action.",
@@ -244,6 +247,67 @@
                                }
                 },
     "orders":  {
+                   "list":  {
+                                 "title":  "My orders",
+                                 "subtitle":  "Review order history, create new orders from your cart, and keep tabs on fulfillment.",
+                                 "actions":  {
+                                                 "refresh":  "Refresh"
+                                             },
+                                 "create":  {
+                                              "title":  "Create order from cart",
+                                              "subtitle":  "Apply shipping and tax to your active cart to generate a new order.",
+                                              "fields":  {
+                                                            "shipping":  "Shipping amount",
+                                                            "shippingHint":  "Flat shipping charge applied to the order.",
+                                                            "taxRate":  "Tax rate",
+                                                            "taxRateHint":  "Enter as a decimal (e.g. 0.07 for 7%)."
+                                                        },
+                                              "errors":  {
+                                                            "shippingMin":  "Shipping cannot be negative.",
+                                                            "taxRateRange":  "Tax rate must be between 0 and 1."
+                                                        },
+                                              "submit":  "Create order"
+                                          },
+                                 "table":  {
+                                              "title":  "Recent orders",
+                                              "count":  "{{ count }} total orders",
+                                              "id":  "Order",
+                                              "total":  "Total",
+                                              "status":  "Status",
+                                              "placed":  "Placed",
+                                              "actions":  "Actions",
+                                              "view":  "View order"
+                                          },
+                                 "status":  {
+                                               "pending":  "Pending",
+                                               "processing":  "Processing",
+                                               "confirmed":  "Confirmed",
+                                               "fulfilled":  "Fulfilled",
+                                               "completed":  "Completed",
+                                               "shipped":  "Shipped",
+                                               "delivered":  "Delivered",
+                                               "cancelled":  "Cancelled",
+                                               "refunded":  "Refunded",
+                                               "failed":  "Failed",
+                                               "unknown":  "Unknown"
+                                           },
+                                 "paymentStatus":  {
+                                                     "paid":  "Paid",
+                                                     "unpaid":  "Unpaid",
+                                                     "pending":  "Pending payment",
+                                                     "refunded":  "Refunded",
+                                                     "failed":  "Payment failed",
+                                                     "unknown":  "Unknown"
+                                                 },
+                                 "empty":  "No orders yet. Create one from your cart to get started.",
+                                 "errors":  {
+                                                "loadFailed":  "Unable to load orders. Please try again.",
+                                                "createFailed":  "We couldn't create the order from your cart."
+                                            },
+                                 "toasts":  {
+                                                "created":  "Order created from your cart."
+                                            }
+                             },
                    "detail":  {
                                   "title":  "Order Detail",
                                   "fields":  {


### PR DESCRIPTION
## Summary
- rebuild the customer orders list with Angular Material components, reactive form handling, and improved API state management
- introduce dedicated styling, localized copy, and CLI analytics disablement to support responsive, accessible builds
- update the project TODO to capture progress on loading states, Material polish, and localization coverage for orders

## Testing
- CI=1 npx ng build --configuration production

------
https://chatgpt.com/codex/tasks/task_e_68cdc116438883249aade410e9737da2