### PR TITLE
Align cart UI with API reference

### DIFF
--- a/admin/TODO.md
+++ b/admin/TODO.md
@@ -51,6 +51,7 @@ Legend
 - [ ] Product variant editor UX (stock/price deltas, variant attributes) and quick duplicate action.
 - [ ] Category tree enhancements (drag/drop reorder, breadcrumbs, badges for children count).
 - [ ] Saved carts, clear-confirmation dialogs, and contextual toasts.
+  - Note: Clear confirmation dialog and cart toasts shipped; saved carts still pending.
 - [ ] Payment provider toggles once Razorpay/PayPal APIs ship (track backend TODOs).
 - [ ] Theme switcher (light/dark), i18n scaffolding, and offline-friendly caches for key screens.
 - [ ] Visual regression stories / Storybook or screenshot tests for critical components.
@@ -84,7 +85,9 @@ Legend
 
 ### Cart & Promotions
 - [x] Cart CRUD (`GET/POST/PATCH/DELETE /api/cart*`).
-- [ ] Coupon apply/remove UI (`POST/DELETE /api/cart/coupon`).
+  - Polished: Cart page now consumes `docs/frontend_api_reference.md` totals/money schema with SKU + ID display.
+- [x] Coupon apply/remove UI (`POST/DELETE /api/cart/coupon`).
+  - Polished: Coupon chips and savings surface metadata from the frontend API reference.
 - [ ] Saved cart snapshot or clear-confirm modal.
 
 ### Orders & Returns

--- a/admin/src/app/pages/cart/cart.component.html
+++ b/admin/src/app/pages/cart/cart.component.html
@@ -1,31 +1,231 @@
-<div class="panel">
-  <h2>My Cart</h2>
-  <p *ngIf="loading" class="muted">Loading…</p>
-  <p *ngIf="error" class="muted">{{ error }}</p>
-  <div *ngIf="cart">
-    <table>
-      <thead>
-        <tr><th>Product</th><th>Price</th><th>Qty</th><th>Line</th><th></th></tr>
-      </thead>
-      <tbody>
-        <tr *ngFor="let it of cart.items">
-          <td>{{ it.name }}</td>
-          <td>{{ it.price | number:'1.2-2' }} {{ it.currency }}</td>
-          <td>
-            <button (click)="dec(it.product, it.quantity)">-</button>
-            <span style="margin:0 8px">{{ it.quantity }}</span>
-            <button (click)="inc(it.product, it.quantity)">+</button>
-          </td>
-          <td>{{ (it.price * it.quantity) | number:'1.2-2' }} {{ it.currency }}</td>
-          <td><button class="danger" (click)="remove(it.product)">Remove</button></td>
-        </tr>
-      </tbody>
-    </table>
-    <div style="display:flex; gap:8px; align-items:center; margin-top:12px;">
-      <strong>Subtotal:</strong> {{ cart.subtotal | number:'1.2-2' }} {{ cart.currency }}
-      <span class="spacer"></span>
-      <button class="danger" (click)="clear()">Clear Cart</button>
+<div class="cart-page">
+  <section class="cart-header panel">
+    <div class="cart-header-text">
+      <h1>{{ 'cart.title' | translate }}</h1>
+      <p class="muted">{{ 'cart.subtitle' | translate }}</p>
     </div>
-  </div>
-</div>
+    <button mat-stroked-button color="primary" type="button" (click)="load()" [disabled]="loading">
+      <mat-icon>refresh</mat-icon>
+      <span>{{ 'cart.actions.refresh' | translate }}</span>
+    </button>
+  </section>
 
+  <section class="cart-body panel">
+    <app-loading [show]="loading" labelKey="common.loading"></app-loading>
+    <app-error-banner [key]="errorKey" [error]="lastError"></app-error-banner>
+
+    <ng-container *ngIf="cart as currentCart">
+      <div class="cart-grid">
+        <div class="cart-table-container">
+          <table mat-table [dataSource]="viewItems" *ngIf="viewItems.length; else emptyState">
+            <ng-container matColumnDef="product">
+              <th mat-header-cell *matHeaderCellDef>{{ 'cart.table.product' | translate }}</th>
+              <td mat-cell *matCellDef="let item">
+                <div class="product-cell">
+                  <span class="product-name">{{ item.name }}</span>
+                  <ng-container *ngIf="item.sku; else productIdentifier">
+                    <span class="product-sku muted">{{ item.sku }}</span>
+                  </ng-container>
+                  <ng-template #productIdentifier>
+                    <span class="product-sku muted">{{ item.productId }}</span>
+                  </ng-template>
+                </div>
+              </td>
+            </ng-container>
+
+            <ng-container matColumnDef="price">
+              <th mat-header-cell *matHeaderCellDef>{{ 'cart.table.price' | translate }}</th>
+              <td mat-cell *matCellDef="let item">
+                {{ item.unit.amount | currency:item.unit.currency:'symbol':'1.2-2' }}
+              </td>
+            </ng-container>
+
+            <ng-container matColumnDef="qty">
+              <th mat-header-cell *matHeaderCellDef>{{ 'cart.table.qty' | translate }}</th>
+              <td mat-cell *matCellDef="let item">
+                <div class="qty-control">
+                  <button
+                    mat-icon-button
+                    type="button"
+                    (click)="dec(item.id)"
+                    [disabled]="pendingItemId === item.id || item.quantity <= 1 || couponLoading || clearing"
+                    [attr.aria-label]="'cart.actions.decrease' | translate"
+                  >
+                    <mat-icon>remove</mat-icon>
+                  </button>
+                  <span class="qty-value">{{ item.quantity }}</span>
+                  <button
+                    mat-icon-button
+                    color="primary"
+                    type="button"
+                    (click)="inc(item.id)"
+                    [disabled]="pendingItemId === item.id || couponLoading || clearing"
+                    [attr.aria-label]="'cart.actions.increase' | translate"
+                  >
+                    <mat-icon>add</mat-icon>
+                  </button>
+                </div>
+              </td>
+            </ng-container>
+
+            <ng-container matColumnDef="line">
+              <th mat-header-cell *matHeaderCellDef>{{ 'cart.table.line' | translate }}</th>
+              <td mat-cell *matCellDef="let item">
+                {{ item.line.amount | currency:item.line.currency:'symbol':'1.2-2' }}
+              </td>
+            </ng-container>
+
+            <ng-container matColumnDef="actions">
+              <th mat-header-cell *matHeaderCellDef>{{ 'cart.table.actions' | translate }}</th>
+              <td mat-cell *matCellDef="let item">
+                <button
+                  mat-icon-button
+                  color="warn"
+                  type="button"
+                  (click)="remove(item.id)"
+                  [disabled]="pendingItemId === item.id || couponLoading || clearing"
+                  [attr.aria-label]="'cart.actions.remove' | translate"
+                >
+                  <ng-container *ngIf="pendingItemId !== item.id; else removing">
+                    <mat-icon>delete</mat-icon>
+                  </ng-container>
+                  <ng-template #removing>
+                    <mat-progress-spinner diameter="20" mode="indeterminate"></mat-progress-spinner>
+                  </ng-template>
+                </button>
+              </td>
+            </ng-container>
+
+            <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: displayedColumns; trackBy: trackById"></tr>
+          </table>
+
+          <ng-template #emptyState>
+            <div class="empty-state">
+              <mat-icon>shopping_cart</mat-icon>
+              <p>{{ 'cart.empty' | translate }}</p>
+            </div>
+          </ng-template>
+        </div>
+
+        <aside class="cart-sidebar">
+          <div class="cart-summary">
+            <h3>{{ 'cart.summary.title' | translate }}</h3>
+            <div class="cart-summary-row">
+              <span>{{ 'cart.summary.subtotal' | translate }}</span>
+              <span>{{ summary.subtotal.amount | currency:summary.subtotal.currency:'symbol':'1.2-2' }}</span>
+            </div>
+            <div class="cart-summary-row" *ngIf="summary.discount as discount">
+              <span>{{ 'cart.summary.discounts' | translate }}</span>
+              <span class="discount">-{{ discount.amount | currency:discount.currency:'symbol':'1.2-2' }}</span>
+            </div>
+            <div class="cart-summary-row" *ngIf="summary.shipping as shippingRow">
+              <span>{{ 'cart.summary.shipping' | translate }}</span>
+              <span>{{ shippingRow.amount | currency:shippingRow.currency:'symbol':'1.2-2' }}</span>
+            </div>
+            <div class="cart-summary-row" *ngIf="summary.tax as taxRow">
+              <span>{{ 'cart.summary.tax' | translate }}</span>
+              <span>{{ taxRow.amount | currency:taxRow.currency:'symbol':'1.2-2' }}</span>
+            </div>
+            <mat-divider></mat-divider>
+            <div class="cart-summary-row total">
+              <span>{{ 'cart.summary.total' | translate }}</span>
+              <span>{{ summary.total.amount | currency:summary.total.currency:'symbol':'1.2-2' }}</span>
+            </div>
+            <div class="cart-summary-meta" *ngIf="cartUpdatedAt">
+              <mat-icon>schedule</mat-icon>
+              <span>{{ 'cart.summary.updated' | translate:{ date: (cartUpdatedAt | date:'medium') } }}</span>
+            </div>
+          </div>
+
+          <div class="coupon-section">
+            <form [formGroup]="couponForm" (ngSubmit)="applyCoupon()" novalidate>
+              <mat-form-field appearance="fill" class="coupon-field">
+                <mat-label>{{ 'cart.coupon.label' | translate }}</mat-label>
+                <input
+                  matInput
+                  formControlName="code"
+                  [placeholder]="'cart.coupon.placeholder' | translate"
+                  [disabled]="couponLoading || clearing || !!pendingItemId"
+                  autocomplete="off"
+                />
+                <mat-error *ngIf="couponForm.controls.code.hasError('required')">
+                  {{ 'cart.coupon.errors.required' | translate }}
+                </mat-error>
+                <mat-error *ngIf="couponForm.controls.code.hasError('minlength')">
+                  {{ 'cart.coupon.errors.minLength' | translate }}
+                </mat-error>
+              </mat-form-field>
+
+              <div class="coupon-actions">
+                <button
+                  mat-raised-button
+                  color="primary"
+                  type="submit"
+                  [disabled]="couponForm.invalid || couponLoading || clearing || !!pendingItemId"
+                >
+                  <ng-container *ngIf="!couponLoading; else applyingCoupon">
+                    <mat-icon>local_offer</mat-icon>
+                  </ng-container>
+                  <ng-template #applyingCoupon>
+                    <mat-progress-spinner diameter="18" mode="indeterminate"></mat-progress-spinner>
+                  </ng-template>
+                  <span>{{ 'cart.coupon.apply' | translate }}</span>
+                </button>
+
+                <button
+                  mat-stroked-button
+                  color="accent"
+                  type="button"
+                  *ngIf="currentCart.coupon"
+                  (click)="removeCoupon()"
+                  [disabled]="couponLoading || clearing || !!pendingItemId"
+                >
+                  <mat-icon>close</mat-icon>
+                  <span>{{ 'cart.coupon.remove' | translate }}</span>
+                </button>
+              </div>
+            </form>
+
+            <div class="coupon-messages">
+              <p class="coupon-success" *ngIf="couponSuccessMessage">{{ couponSuccessMessage }}</p>
+              <p class="coupon-error" *ngIf="couponErrorMessage">{{ couponErrorMessage }}</p>
+            </div>
+
+            <div class="coupon-applied" *ngIf="currentCart.coupon">
+              <mat-chip-set>
+                <mat-chip color="primary" selected>{{ currentCart.coupon.code }}</mat-chip>
+              </mat-chip-set>
+              <div class="coupon-details">
+                <span *ngIf="currentCart.coupon.name">{{ currentCart.coupon.name }}</span>
+                <span *ngIf="currentCart.coupon.description">{{ currentCart.coupon.description }}</span>
+                <span *ngIf="couponSavings" class="muted">
+                  {{ 'cart.coupon.savingsLabel' | translate }}:
+                  <strong>{{ couponSavings.amount | currency:couponSavings.currency:'symbol':'1.2-2' }}</strong>
+                </span>
+              </div>
+            </div>
+          </div>
+        </aside>
+      </div>
+    </ng-container>
+
+    <div class="cart-actions" *ngIf="viewItems.length">
+      <button
+        mat-stroked-button
+        color="warn"
+        type="button"
+        (click)="confirmClear()"
+        [disabled]="clearing || couponLoading || !!pendingItemId"
+      >
+        <ng-container *ngIf="!clearing; else clearingSpinner">
+          <mat-icon>delete_sweep</mat-icon>
+        </ng-container>
+        <ng-template #clearingSpinner>
+          <mat-progress-spinner diameter="18" mode="indeterminate"></mat-progress-spinner>
+        </ng-template>
+        <span>{{ 'cart.actions.clear' | translate }}</span>
+      </button>
+    </div>
+  </section>
+</div>

--- a/admin/src/app/pages/cart/cart.component.scss
+++ b/admin/src/app/pages/cart/cart.component.scss
@@ -1,0 +1,223 @@
+.cart-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.cart-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.cart-header-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.cart-header-text h1 {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+}
+
+.muted {
+  margin: 0;
+  color: var(--app-text-muted);
+}
+
+.cart-body {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.cart-grid {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 960px) {
+  .cart-grid {
+    grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  }
+}
+
+.cart-table-container {
+  overflow-x: auto;
+}
+
+.product-cell {
+  display: flex;
+  flex-direction: column;
+}
+
+.product-name {
+  font-weight: 500;
+}
+
+.product-sku {
+  font-size: 12px;
+}
+
+.qty-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.qty-value {
+  min-width: 24px;
+  text-align: center;
+  font-weight: 600;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 32px 0;
+  color: var(--app-text-muted);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.empty-state mat-icon {
+  font-size: 42px;
+  width: 42px;
+  height: 42px;
+}
+
+.cart-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.cart-summary { 
+  background: var(--app-surface-elevated);
+  border: 1px solid var(--app-border);
+  border-radius: 16px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.cart-summary h3 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.cart-summary-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 15px;
+}
+
+.cart-summary-row.total {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.cart-summary-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--app-text-muted);
+}
+
+.cart-summary-meta mat-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+}
+
+.discount {
+  color: var(--app-success);
+}
+
+.coupon-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.coupon-field {
+  width: 100%;
+}
+
+.coupon-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.coupon-actions button mat-progress-spinner {
+  margin-right: 8px;
+}
+
+.coupon-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.coupon-success {
+  margin: 0;
+  color: var(--app-success);
+}
+
+.coupon-error {
+  margin: 0;
+  color: var(--app-danger);
+}
+
+.coupon-applied {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.coupon-details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.coupon-details .muted {
+  font-size: 13px;
+}
+
+.cart-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.cart-actions button mat-progress-spinner {
+  margin-right: 8px;
+}
+
+.cart-actions button mat-icon,
+.coupon-actions button mat-icon {
+  margin-right: 8px;
+}
+
+.cart-actions button mat-progress-spinner,
+.coupon-actions button mat-progress-spinner {
+  width: 18px;
+  height: 18px;
+}
+
+.cart-actions button mat-progress-spinner svg,
+.coupon-actions button mat-progress-spinner svg {
+  stroke: currentColor;
+}

--- a/admin/src/app/pages/cart/cart.component.ts
+++ b/admin/src/app/pages/cart/cart.component.ts
@@ -1,34 +1,442 @@
-import { Component, OnInit } from '@angular/core';
-import { CartService, Cart } from '../../services/cart.service';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { FormBuilder, Validators } from '@angular/forms';
+import { MatDialog } from '@angular/material/dialog';
+import { TranslateService } from '@ngx-translate/core';
 
-@Component({ selector: 'app-cart', templateUrl: './cart.component.html' })
+import { ToastService } from '../../core/toast.service';
+import { CartService, Cart, CartItem, MoneyAmount } from '../../services/cart.service';
+import { ConfirmDialogComponent } from '../../shared/confirm-dialog.component';
+
+interface DisplayMoney {
+  amount: number;
+  currency: string;
+}
+
+interface DisplayCartItem {
+  id: string;
+  productId: string;
+  name: string;
+  sku?: string | null;
+  quantity: number;
+  unit: DisplayMoney;
+  line: DisplayMoney;
+  image?: string | null;
+}
+
+@Component({
+  selector: 'app-cart',
+  templateUrl: './cart.component.html',
+  styleUrls: ['./cart.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
 export class CartComponent implements OnInit {
   cart: Cart | null = null;
   loading = false;
-  error = '';
+  clearing = false;
+  couponLoading = false;
+  pendingItemId: string | null = null;
+  errorKey: string | null = null;
+  lastError: any = null;
+  couponErrorMessage: string | null = null;
+  couponSuccessMessage: string | null = null;
 
-  constructor(private cartSvc: CartService) {}
+  readonly displayedColumns: string[] = ['product', 'price', 'qty', 'line', 'actions'];
 
-  ngOnInit() { this.load(); }
+  readonly couponForm = this.fb.group({
+    code: ['', [Validators.required, Validators.minLength(2)]]
+  });
 
-  load() {
-    this.loading = true; this.error = '';
-    this.cartSvc.get().subscribe({ next: ({ cart }) => { this.cart = cart; this.loading = false; }, error: (err) => { this.loading = false; this.error = err?.error?.error?.message || 'Failed'; } });
+  viewItems: DisplayCartItem[] = [];
+  summary = {
+    subtotal: { amount: 0, currency: 'USD' } as DisplayMoney,
+    discount: null as DisplayMoney | null,
+    shipping: null as DisplayMoney | null,
+    tax: null as DisplayMoney | null,
+    total: { amount: 0, currency: 'USD' } as DisplayMoney
+  };
+  couponSavings: DisplayMoney | null = null;
+  cartUpdatedAt: string | null = null;
+
+  private cartCurrency = 'USD';
+  private readonly cartItemsById = new Map<string, CartItem>();
+
+  constructor(
+    private readonly cartSvc: CartService,
+    private readonly fb: FormBuilder,
+    private readonly dialog: MatDialog,
+    private readonly toast: ToastService,
+    private readonly translate: TranslateService,
+    private readonly cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit(): void {
+    this.load();
   }
 
-  inc(p: string, q: number) {
-    const newQ = q + 1;
-    this.cartSvc.updateItem(p, newQ).subscribe({ next: ({ cart }) => { this.cart = cart; }, error: () => {} });
+  load(): void {
+    this.loading = true;
+    this.errorKey = null;
+    this.lastError = null;
+    this.cdr.markForCheck();
+
+    this.cartSvc.get().subscribe({
+      next: ({ cart }) => {
+        this.updateCart(cart);
+        this.loading = false;
+        this.resetCouponMessages();
+        this.cdr.markForCheck();
+      },
+      error: (err) => {
+        this.loading = false;
+        this.lastError = err;
+        const code = err?.error?.error?.code;
+        this.errorKey = code ? `errors.backend.${code}` : 'cart.errors.loadFailed';
+        this.cdr.markForCheck();
+      }
+    });
   }
-  dec(p: string, q: number) {
-    const newQ = Math.max(1, q - 1);
-    this.cartSvc.updateItem(p, newQ).subscribe({ next: ({ cart }) => { this.cart = cart; }, error: () => {} });
+
+  inc(itemId: string): void {
+    const item = this.cartItemsById.get(itemId);
+    if (!item) {
+      return;
+    }
+    const next = this.coerceQuantity(item.quantity) + 1;
+    this.updateQuantity(itemId, item, next);
   }
-  remove(p: string) {
-    this.cartSvc.removeItem(p).subscribe({ next: ({ cart }) => { this.cart = cart; }, error: () => {} });
+
+  dec(itemId: string): void {
+    const item = this.cartItemsById.get(itemId);
+    if (!item) {
+      return;
+    }
+    const next = Math.max(this.coerceQuantity(item.quantity) - 1, 1);
+    this.updateQuantity(itemId, item, next);
   }
-  clear() {
-    this.cartSvc.clear().subscribe({ next: ({ cart }) => { this.cart = cart; }, error: () => {} });
+
+  remove(itemId: string): void {
+    const item = this.cartItemsById.get(itemId);
+    if (!item) {
+      return;
+    }
+
+    const endpointId = this.resolveItemEndpointId(item);
+    if (!endpointId) {
+      return;
+    }
+
+    this.pendingItemId = itemId;
+    this.cdr.markForCheck();
+
+    this.cartSvc.removeItem(endpointId).subscribe({
+      next: ({ cart }) => {
+        this.updateCart(cart);
+        this.pendingItemId = null;
+        const message = this.translate.instant('cart.toasts.itemRemoved', {
+          name: this.resolveItemName(item)
+        });
+        this.toast.success(message);
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        this.pendingItemId = null;
+        const message = this.translate.instant('cart.errors.removeFailed');
+        this.toast.error(message);
+        this.cdr.markForCheck();
+      }
+    });
+  }
+
+  confirmClear(): void {
+    if (!this.viewItems.length || this.clearing || this.loading) {
+      return;
+    }
+
+    const ref = this.dialog.open(ConfirmDialogComponent, {
+      width: '360px',
+      data: {
+        titleKey: 'cart.clearConfirm.title',
+        messageKey: 'cart.clearConfirm.message',
+        confirmKey: 'cart.actions.clear'
+      }
+    });
+
+    ref.afterClosed().subscribe((confirmed) => {
+      if (confirmed) {
+        this.clearCart();
+      }
+    });
+  }
+
+  applyCoupon(): void {
+    if (this.couponLoading || this.couponForm.invalid) {
+      this.couponForm.markAllAsTouched();
+      return;
+    }
+
+    const code = (this.couponForm.value.code || '').trim();
+    if (!code) {
+      this.couponForm.markAllAsTouched();
+      return;
+    }
+
+    this.couponLoading = true;
+    this.couponErrorMessage = null;
+    this.couponSuccessMessage = null;
+    this.cdr.markForCheck();
+
+    this.cartSvc.applyCoupon(code).subscribe({
+      next: ({ cart }) => {
+        this.updateCart(cart);
+        this.couponLoading = false;
+        const appliedCode = cart?.coupon?.code || code;
+        const message = this.translate.instant('cart.toasts.couponApplied', { code: appliedCode });
+        this.couponSuccessMessage = message;
+        this.toast.success(message);
+        this.cdr.markForCheck();
+      },
+      error: (err) => {
+        this.couponLoading = false;
+        const message = this.resolveErrorMessage(err, 'cart.coupon.applyFailed', { code });
+        this.couponErrorMessage = message;
+        this.toast.error(message);
+        this.cdr.markForCheck();
+      }
+    });
+  }
+
+  removeCoupon(): void {
+    if (this.couponLoading || !this.cart?.coupon) {
+      return;
+    }
+
+    this.couponLoading = true;
+    this.couponErrorMessage = null;
+    this.couponSuccessMessage = null;
+    this.cdr.markForCheck();
+
+    this.cartSvc.removeCoupon().subscribe({
+      next: ({ cart }) => {
+        this.updateCart(cart);
+        this.couponLoading = false;
+        const message = this.translate.instant('cart.toasts.couponRemoved');
+        this.couponSuccessMessage = message;
+        this.toast.success(message);
+        this.cdr.markForCheck();
+      },
+      error: (err) => {
+        this.couponLoading = false;
+        const message = this.resolveErrorMessage(err, 'cart.coupon.removeFailed');
+        this.couponErrorMessage = message;
+        this.toast.error(message);
+        this.cdr.markForCheck();
+      }
+    });
+  }
+
+  trackById(_: number, item: DisplayCartItem): string {
+    return item.id;
+  }
+
+  private updateCart(cart: Cart): void {
+    const prevCode = this.cart?.coupon?.code || '';
+    const nextCode = cart?.coupon?.code || '';
+    const currency = this.detectCurrency(cart);
+    this.cartCurrency = currency;
+
+    this.cartItemsById.clear();
+    this.viewItems = (cart.items ?? []).map((item, index) => {
+      const id = this.resolveItemId(item, index);
+      const quantity = this.coerceQuantity(item.quantity);
+      const unit = this.normalizeMoney(item.unitPrice ?? item.totals?.unit ?? item.price, currency);
+      const lineSource = item.lineTotal ?? item.totals?.line ?? (typeof item.price === 'number' ? item.price * quantity : undefined);
+      const line = this.normalizeMoney(lineSource, unit.currency);
+      const productId = this.resolveProductId(item, id);
+      const name = this.resolveItemName(item);
+      const sku = item.sku ?? item.productData?.sku ?? null;
+      const image = item.image ?? null;
+
+      this.cartItemsById.set(id, item);
+
+      return { id, productId, name, sku, quantity, unit, line, image };
+    });
+
+    const subtotal = this.normalizeMoney(cart.totals?.subtotal ?? cart.subtotal, currency);
+    const discountValue = cart.totals?.discountTotal ?? cart.discountTotal ?? cart.coupon?.discountAmount ?? cart.coupon?.amountOff;
+    const discount = this.normalizeMoney(discountValue, currency);
+    const shipping = this.normalizeMoney(cart.totals?.shippingTotal ?? cart.shipping, currency);
+    const tax = this.normalizeMoney(cart.totals?.taxTotal ?? cart.tax, currency);
+    const totalSource =
+      cart.totals?.total ??
+      cart.total ??
+      subtotal.amount - (discount.amount > 0 ? discount.amount : 0) + (shipping.amount > 0 ? shipping.amount : 0) + (tax.amount > 0 ? tax.amount : 0);
+    const total = this.normalizeMoney(totalSource, currency);
+
+    this.summary = {
+      subtotal,
+      discount: discount.amount > 0 ? discount : null,
+      shipping: shipping.amount > 0 ? shipping : null,
+      tax: tax.amount > 0 ? tax : null,
+      total
+    };
+
+    if (cart.coupon) {
+      const couponSavings = this.summary.discount ?? this.normalizeMoney(cart.coupon.discountAmount ?? cart.coupon.amountOff, currency);
+      this.couponSavings = couponSavings.amount > 0 ? couponSavings : null;
+    } else {
+      this.couponSavings = null;
+    }
+
+    this.cartUpdatedAt = this.resolveUpdatedAt(cart);
+
+    this.cart = cart;
+    if (prevCode !== nextCode) {
+      this.couponForm.patchValue({ code: nextCode }, { emitEvent: false });
+    }
+  }
+
+  private clearCart(): void {
+    this.clearing = true;
+    this.cdr.markForCheck();
+
+    this.cartSvc.clear().subscribe({
+      next: ({ cart }) => {
+        this.updateCart(cart);
+        this.clearing = false;
+        const message = this.translate.instant('cart.toasts.cleared');
+        this.toast.success(message);
+        this.resetCouponMessages();
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        this.clearing = false;
+        const message = this.translate.instant('cart.errors.clearFailed');
+        this.toast.error(message);
+        this.cdr.markForCheck();
+      }
+    });
+  }
+
+  private updateQuantity(displayId: string, item: CartItem, quantity: number): void {
+    const endpointId = this.resolveItemEndpointId(item);
+    if (!endpointId) {
+      return;
+    }
+
+    this.pendingItemId = displayId;
+    this.cdr.markForCheck();
+
+    this.cartSvc.updateItem(endpointId, quantity).subscribe({
+      next: ({ cart }) => {
+        this.updateCart(cart);
+        this.pendingItemId = null;
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        this.pendingItemId = null;
+        const message = this.translate.instant('cart.errors.updateFailed');
+        this.toast.error(message);
+        this.cdr.markForCheck();
+      }
+    });
+  }
+
+  private resolveErrorMessage(err: any, fallbackKey: string, params?: Record<string, unknown>): string {
+    const code = err?.error?.error?.code;
+    const key = code ? `errors.backend.${code}` : fallbackKey;
+    return this.translate.instant(key, params);
+  }
+
+  private resetCouponMessages(): void {
+    this.couponErrorMessage = null;
+    this.couponSuccessMessage = null;
+  }
+
+  private detectCurrency(cart: Cart): string {
+    const fromCart =
+      cart.currency ||
+      this.extractCurrency(cart.totals?.total) ||
+      this.extractCurrency(cart.totals?.subtotal) ||
+      this.extractCurrency(cart.totals?.discountTotal);
+    if (fromCart) {
+      return fromCart;
+    }
+
+    for (const item of cart.items ?? []) {
+      const itemCurrency =
+        item.currency ||
+        this.extractCurrency(item.unitPrice) ||
+        this.extractCurrency(item.totals?.unit) ||
+        this.extractCurrency(item.lineTotal) ||
+        this.extractCurrency(item.totals?.line);
+      if (itemCurrency) {
+        return itemCurrency;
+      }
+    }
+
+    return 'USD';
+  }
+
+  private extractCurrency(value: number | MoneyAmount | null | undefined): string | null {
+    if (this.isMoneyAmount(value) && value.currency) {
+      return value.currency;
+    }
+    return null;
+  }
+
+  private normalizeMoney(value: number | MoneyAmount | null | undefined, fallbackCurrency: string): DisplayMoney {
+    if (this.isMoneyAmount(value)) {
+      const amount = Number(value.amount ?? 0);
+      const currency = value.currency || fallbackCurrency || this.cartCurrency || 'USD';
+      return { amount: Number.isFinite(amount) ? amount : 0, currency };
+    }
+
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return { amount: value, currency: fallbackCurrency || this.cartCurrency || 'USD' };
+    }
+
+    return { amount: 0, currency: fallbackCurrency || this.cartCurrency || 'USD' };
+  }
+
+  private resolveItemId(item: CartItem, index: number): string {
+    return item._id || item.itemId || item.product || item.productId || `row-${index}`;
+  }
+
+  private resolveItemEndpointId(item: CartItem): string | null {
+    return item._id || item.itemId || item.product || item.productId || null;
+  }
+
+  private resolveProductId(item: CartItem, fallback: string): string {
+    return item.product || item.productId || fallback;
+  }
+
+  private resolveItemName(item: CartItem): string {
+    return item.name || item.productData?.name || item.product || item.productId || this.translate.instant('cart.table.unknownProduct');
+  }
+
+  private coerceQuantity(quantity: number | null | undefined): number {
+    if (typeof quantity === 'number' && Number.isFinite(quantity)) {
+      return quantity;
+    }
+    return 0;
+  }
+
+  private isMoneyAmount(value: unknown): value is MoneyAmount {
+    return typeof value === 'object' && value !== null && 'amount' in value;
+  }
+
+  private resolveUpdatedAt(cart: Cart): string | null {
+    if (cart.updatedAt) {
+      return cart.updatedAt;
+    }
+
+    const record = cart as Record<string, unknown>;
+    const updated = record?.['updated'];
+    if (typeof updated === 'string') {
+      return updated;
+    }
+
+    const updatedAt = record?.['updated_at'];
+    return typeof updatedAt === 'string' ? updatedAt : null;
   }
 }
-

--- a/admin/src/app/services/cart.service.ts
+++ b/admin/src/app/services/cart.service.ts
@@ -3,8 +3,74 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 
-export interface CartItem { product: string; name: string; price: number; currency: string; quantity: number; }
-export interface Cart { _id: string; user: string; items: CartItem[]; subtotal: number; currency: string; status: string; }
+export interface MoneyAmount {
+  amount: number;
+  currency: string;
+}
+
+export interface CartItemTotals {
+  unit?: MoneyAmount | null;
+  line?: MoneyAmount | null;
+}
+
+export interface CartItemProduct {
+  _id?: string | null;
+  name?: string | null;
+  slug?: string | null;
+  sku?: string | null;
+}
+
+export interface CartItem {
+  _id?: string | null;
+  itemId?: string | null;
+  product?: string | null;
+  productId?: string | null;
+  sku?: string | null;
+  name?: string | null;
+  price?: number | null;
+  currency?: string | null;
+  quantity: number;
+  unitPrice?: MoneyAmount | null;
+  lineTotal?: MoneyAmount | null;
+  totals?: CartItemTotals | null;
+  image?: string | null;
+  productData?: CartItemProduct | null;
+}
+
+export interface CartCoupon {
+  code: string;
+  name?: string | null;
+  description?: string | null;
+  discountAmount?: number | MoneyAmount | null;
+  amountOff?: number | MoneyAmount | null;
+  percentOff?: number | null;
+  type?: 'percentage' | 'fixed' | string;
+}
+
+export interface CartTotals {
+  subtotal?: number | MoneyAmount | null;
+  discountTotal?: number | MoneyAmount | null;
+  shippingTotal?: number | MoneyAmount | null;
+  taxTotal?: number | MoneyAmount | null;
+  total?: number | MoneyAmount | null;
+}
+
+export interface Cart {
+  _id?: string | null;
+  id?: string | null;
+  user?: string | null;
+  items: CartItem[];
+  subtotal?: number | null;
+  discountTotal?: number | null;
+  shipping?: number | null;
+  tax?: number | null;
+  total?: number | null;
+  currency?: string | null;
+  status?: string | null;
+  coupon?: CartCoupon | null;
+  totals?: CartTotals | null;
+  updatedAt?: string | null;
+}
 
 @Injectable({ providedIn: 'root' })
 export class CartService {
@@ -16,5 +82,13 @@ export class CartService {
   updateItem(productId: string, quantity: number): Observable<{ cart: Cart }> { return this.http.patch<{ cart: Cart }>(`${this.base}/items/${productId}`, { quantity }); }
   removeItem(productId: string): Observable<{ cart: Cart }> { return this.http.delete<{ cart: Cart }>(`${this.base}/items/${productId}`); }
   clear(): Observable<{ cart: Cart }> { return this.http.post<{ cart: Cart }>(`${this.base}/clear`, {}); }
+
+  applyCoupon(code: string): Observable<{ cart: Cart }> {
+    return this.http.post<{ cart: Cart }>(`${this.base}/coupon`, { code });
+  }
+
+  removeCoupon(): Observable<{ cart: Cart }> {
+    return this.http.delete<{ cart: Cart }>(`${this.base}/coupon`);
+  }
 }
 

--- a/admin/src/assets/i18n/en.json
+++ b/admin/src/assets/i18n/en.json
@@ -246,6 +246,64 @@
                                    "preferencesSaveFailed":  "Unable to save preferences."
                                }
                 },
+    "cart":  {
+                 "title":  "My cart",
+                 "subtitle":  "Review items in your cart before creating an order.",
+                 "actions":  {
+                               "refresh":  "Refresh",
+                               "clear":  "Clear cart",
+                               "increase":  "Increase quantity",
+                               "decrease":  "Decrease quantity",
+                               "remove":  "Remove item"
+                             },
+                 "table":  {
+                              "product":  "Product",
+                              "price":  "Price",
+                              "qty":  "Qty",
+                              "line":  "Line",
+                              "actions":  "Actions",
+                              "unknownProduct":  "Unknown product"
+                            },
+                 "empty":  "Your cart is empty.",
+                 "summary":  {
+                                 "title":  "Cart summary",
+                                 "subtotal":  "Subtotal",
+                                 "discounts":  "Discounts",
+                                 "shipping":  "Shipping",
+                                 "tax":  "Tax",
+                                 "total":  "Total",
+                                 "updated":  "Updated {{ date }}"
+                               },
+                 "coupon":  {
+                                "label":  "Coupon code",
+                                "placeholder":  "Enter coupon",
+                                "apply":  "Apply coupon",
+                                "remove":  "Remove coupon",
+                                "savingsLabel":  "Savings",
+                                "errors":  {
+                                                "required":  "Coupon code is required.",
+                                                "minLength":  "Coupon code is too short."
+                                            },
+                                "applyFailed":  "We couldn't apply that coupon.",
+                                "removeFailed":  "We couldn't remove the coupon."
+                              },
+                 "clearConfirm":  {
+                                      "title":  "Clear cart?",
+                                      "message":  "This will remove every item from the cart."
+                                    },
+                 "toasts":  {
+                               "couponApplied":  "Coupon {{ code }} applied.",
+                               "couponRemoved":  "Coupon removed.",
+                               "itemRemoved":  "{{ name }} removed from the cart.",
+                               "cleared":  "Cart cleared."
+                             },
+                 "errors":  {
+                               "loadFailed":  "Unable to load cart.",
+                               "updateFailed":  "Unable to update the cart.",
+                               "removeFailed":  "Unable to remove the item.",
+                               "clearFailed":  "Unable to clear the cart."
+                             }
+             },
     "orders":  {
                    "list":  {
                                  "title":  "My orders",


### PR DESCRIPTION
## Summary
- update cart service types and component logic to consume the frontend API reference money/totals schema and expose stable item identifiers
- refresh the cart template, styles, and translations to surface SKU fallback, shipping/tax rows, coupon metadata, and updated timestamp per the reference docs
- note the TODO cart items as polished based on docs/frontend_api_reference.md guidance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce46ed0c9083248b94e7c6095df5a0