### PR TITLE
feat: enhance auth interceptor for API calls

### DIFF
--- a/admin/src/app/core/auth.interceptor.ts
+++ b/admin/src/app/core/auth.interceptor.ts
@@ -14,6 +14,24 @@ import { ToastService } from './toast.service';
 import { TranslateService } from '@ngx-translate/core';
 import { AuthService } from './auth.service';
 
+type HttpMethodWithBody = 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+interface BackendErrorDetails {
+  name?: string;
+  message?: string;
+  code?: string;
+  details?: any;
+  friendlyMessage?: string;
+  translationKey?: string | null;
+}
+
+interface BackendErrorPayload {
+  error?: BackendErrorDetails;
+  friendlyMessage?: string;
+  translationKey?: string | null;
+  [key: string]: any;
+}
+
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
   private refreshing = false;
@@ -25,8 +43,18 @@ export class AuthInterceptor implements HttpInterceptor {
     private i18n: TranslateService
   ) {}
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    const token = this.auth.token;
-    const authReq = token ? req.clone({ setHeaders: { Authorization: `Bearer ${token}` } }) : req;
+    const storedToken = this.auth.token || localStorage.getItem('auth_token');
+    const idempotencyKey = this.shouldAttachIdempotencyKey(req.method) ? this.generateIdempotencyKey() : null;
+
+    const setHeaders: Record<string, string> = {};
+    if (storedToken) {
+      setHeaders.Authorization = `Bearer ${storedToken}`;
+    }
+    if (idempotencyKey) {
+      setHeaders['Idempotency-Key'] = idempotencyKey;
+    }
+
+    const authReq = Object.keys(setHeaders).length ? req.clone({ setHeaders }) : req;
 
     return next.handle(authReq).pipe(
       tap((event) => {
@@ -35,14 +63,15 @@ export class AuthInterceptor implements HttpInterceptor {
         }
       }),
       catchError((err: HttpErrorResponse) => {
-        const url = req.url || '';
+        const enhancedError = this.enhanceError(err, authReq.url || req.url || '');
+        const url = authReq.url || req.url || '';
         const isAuthEndpoint = url.includes('/auth/login') || url.includes('/auth/refresh');
-        if (err.status === 401 && !isAuthEndpoint) {
+        if (enhancedError.status === 401 && !isAuthEndpoint) {
           this.consecutive401 += 1;
           // If refresh already failed or we've seen repeated unauthorized responses, end the session.
           if (this.consecutive401 >= 2 || this.refreshing) {
             this.handleSessionExpired();
-            return throwError(() => err);
+            return throwError(() => enhancedError);
           }
           this.refreshing = true;
           return this.auth.refresh().pipe(
@@ -50,25 +79,30 @@ export class AuthInterceptor implements HttpInterceptor {
               this.refreshing = false;
               if (!res || !res.token) {
                 this.handleSessionExpired();
-                return throwError(() => err);
+                return throwError(() => enhancedError);
               }
-              const retried = req.clone({ setHeaders: { Authorization: `Bearer ${res.token}` } });
+              const retryHeaders: Record<string, string> = { Authorization: `Bearer ${res.token}` };
+              if (idempotencyKey) {
+                retryHeaders['Idempotency-Key'] = idempotencyKey;
+              }
+              const retried = req.clone({ setHeaders: retryHeaders });
               return next.handle(retried);
             }),
             catchError((e) => {
               this.refreshing = false;
               this.handleSessionExpired();
-              return throwError(() => e);
+              const finalError = e instanceof HttpErrorResponse ? this.enhanceError(e, authReq.url || req.url || '') : enhancedError;
+              return throwError(() => finalError);
             })
           );
-        } else if (err.status === 403) {
+        } else if (enhancedError.status === 403) {
           // Access denied for current user/role
           this.toast.error(this.i18n.instant('auth.errors.accessDenied'));
           // if currently on an admin route or action, nudge back to dashboard
           this.router.navigate(['/denied']);
-          return throwError(() => err);
+          return throwError(() => enhancedError);
         }
-        return throwError(() => err);
+        return throwError(() => enhancedError);
       })
     );
   }
@@ -79,5 +113,91 @@ export class AuthInterceptor implements HttpInterceptor {
     this.auth.logout();
     this.router.navigate(['/login']);
     this.toast.error(this.i18n.instant('auth.errors.sessionExpired'));
+  }
+
+  private shouldAttachIdempotencyKey(method?: string | null): method is HttpMethodWithBody {
+    if (!method) {
+      return false;
+    }
+    const upper = method.toUpperCase() as HttpMethodWithBody | string;
+    return upper === 'POST' || upper === 'PUT' || upper === 'PATCH' || upper === 'DELETE';
+  }
+
+  private generateIdempotencyKey(): string {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+    // Fallback RFC4122 v4 implementation
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+      const r = Math.random() * 16 | 0;
+      const v = c === 'x' ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+  }
+
+  private enhanceError(err: HttpErrorResponse, requestUrl: string): HttpErrorResponse {
+    if (!(err instanceof HttpErrorResponse)) {
+      return err;
+    }
+
+    const payload: BackendErrorPayload = this.normalizePayload(err.error);
+    const backendError = payload.error;
+
+    const translationKey = backendError?.code ? `errors.backend.${backendError.code}` : null;
+    const resolvedMessage = this.resolveErrorMessage(payload, translationKey);
+
+    const enrichedPayload: BackendErrorPayload = {
+      ...payload,
+      error: backendError ? { ...backendError, friendlyMessage: resolvedMessage, translationKey } : backendError,
+      friendlyMessage: resolvedMessage,
+      translationKey
+    };
+
+    return new HttpErrorResponse({
+      error: enrichedPayload,
+      headers: err.headers,
+      status: err.status,
+      statusText: err.statusText,
+      url: err.url || requestUrl
+    });
+  }
+
+  private normalizePayload(error: any): BackendErrorPayload {
+    if (error && typeof error === 'object') {
+      return error as BackendErrorPayload;
+    }
+    if (typeof error === 'string') {
+      return { friendlyMessage: error };
+    }
+    return {};
+  }
+
+  private resolveErrorMessage(payload: BackendErrorPayload, translationKey: string | null): string {
+    const backendError = payload.error;
+
+    if (translationKey) {
+      const translated = this.i18n.instant(translationKey, backendError?.details ?? {});
+      if (translated && translated !== translationKey) {
+        return translated;
+      }
+    }
+
+    if (payload.friendlyMessage) {
+      return payload.friendlyMessage;
+    }
+
+    if (backendError?.friendlyMessage) {
+      return backendError.friendlyMessage;
+    }
+
+    if (backendError?.message) {
+      return backendError.message;
+    }
+
+    if (translationKey) {
+      return this.i18n.instant('errors.backend.default', { code: backendError?.code || 'UNKNOWN' });
+    }
+
+    return this.i18n.instant('errors.backend.default', { code: 'UNKNOWN' });
   }
 }

--- a/admin/src/app/shared/error-banner.component.ts
+++ b/admin/src/app/shared/error-banner.component.ts
@@ -37,19 +37,32 @@ export class ErrorBannerComponent {
       return { key: this.key };
     }
 
-    const code = this.error?.error?.error?.code;
-    if (!code) {
-      return null;
+    const backendError = this.error?.error?.error;
+    const code = backendError?.code;
+    const backendKey = code ? `errors.backend.${code}` : null;
+
+    if (backendKey) {
+      const translated = this.translate.instant(backendKey, backendError?.details ?? {});
+      if (translated && translated !== backendKey) {
+        return { key: backendKey, params: backendError?.details };
+      }
     }
 
-    const backendKey = `errors.backend.${code}`;
-    const translated = this.translate.instant(backendKey);
+    const friendlyMessage =
+      this.error?.error?.friendlyMessage ||
+      backendError?.friendlyMessage ||
+      backendError?.message ||
+      (typeof this.error?.error === 'string' ? this.error.error : null);
 
-    if (translated && translated !== backendKey) {
-      return { key: backendKey };
+    if (friendlyMessage) {
+      return { key: friendlyMessage };
     }
 
-    return { key: 'errors.backend.default', params: { code } };
+    if (code) {
+      return { key: 'errors.backend.default', params: { code } };
+    }
+
+    return null;
   }
 }
 

--- a/admin/src/environments/environment.prod.ts
+++ b/admin/src/environments/environment.prod.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: true,
-  apiBaseUrl: '/api'
+  // TODO: replace with the production API base URL when available.
+  apiBaseUrl: '<<PRODUCTION_API_BASE_URL>>'
 };
 

--- a/admin/src/environments/environment.ts
+++ b/admin/src/environments/environment.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: false,
-  // If using dev-server proxy, keep '/api'. Otherwise point to full backend URL.
-  apiBaseUrl: '/api'
+  // Local development API endpoint
+  apiBaseUrl: 'http://localhost:4001/api'
 };
 


### PR DESCRIPTION
## Summary
- configure API base URLs for development and production environments
- enhance the auth HTTP interceptor to add auth and idempotency headers plus richer error handling
- extend the error banner to show friendly messages from backend responses

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce96e946408324a7912ace4e286abb